### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Google Inc.
 Pascal Borreli <pascal@borreli.com>
+Kevin Kirsche <kev.kirsche@gmail.com>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "lovefield",
-  "version": "2.0.57",
   "homepage": "https://github.com/google/lovefield",
   "authors": [
     "Google Inc."


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property