### PR TITLE
fix webworker/systemjs compatibility issue

### DIFF
--- a/dist/lovefield.js
+++ b/dist/lovefield.js
@@ -1,6 +1,6 @@
-if(!self.window){window=this;}
+if(!self.window){window=self;}
 (function(){'use strict';var $jscomp = {scope:{}}, goog = goog || {};
-goog.global = this;
+goog.global = self;
 goog.isDef = function(val) {
   return void 0 !== val;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lovefield",
   "version": "2.0.66",
-  "main": "dist/lovefield.min.js",
+  "main": "dist/lovefield.js",
   "description": "Lovefield - A relational database for web apps",
   "keywords": [
     "lovefield"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lovefield",
-  "version": "2.0.66",
+  "version": "2.0.66-beta1",
   "main": "dist/lovefield.js",
   "description": "Lovefield - A relational database for web apps",
   "keywords": [


### PR DESCRIPTION
when using systemjs module loader, 'this' no longer references the global window object. I modified dist/lovefield.js to show the fix for this. btw. where is the entry point in /lib? I looked and didn't see which file was the main.