### PR TITLE
fixed typing spec for addForeignKey

### DIFF
--- a/dist/lovefield.d.ts
+++ b/dist/lovefield.d.ts
@@ -213,7 +213,7 @@ declare module lf {
       local: string
       ref: string
       action: lf.ConstraintAction
-      timing: lf.ConstraintAction
+      timing: lf.ConstraintTiming
     }
 
     export interface TableBuilder {


### PR DESCRIPTION
There is a mistake in Typescript definition file (spec for addForeignKey method)