### PR TITLE
Feature/exception reporting can npe

### DIFF
--- a/lib/exception.js
+++ b/lib/exception.js
@@ -44,7 +44,7 @@ lf.Exception = function(code, var_args) {
     // Allow at most 4 parameters, each parameter at most 64 chars.
     for (var i = 1; i <= Math.min(4, arguments.length - 1); ++i) {
       this.message += '&p' + (i - 1) + '=' +
-          encodeURIComponent((arguments[i] || '').toString().slice(0, 64));
+          encodeURIComponent(String(arguments[i]).slice(0, 64));
     }
   }
 };

--- a/lib/exception.js
+++ b/lib/exception.js
@@ -44,7 +44,7 @@ lf.Exception = function(code, var_args) {
     // Allow at most 4 parameters, each parameter at most 64 chars.
     for (var i = 1; i <= Math.min(4, arguments.length - 1); ++i) {
       this.message += '&p' + (i - 1) + '=' +
-          encodeURIComponent(arguments[i].toString().slice(0, 64));
+          encodeURIComponent((arguments[i] || '').toString().slice(0, 64));
     }
   }
 };

--- a/tests/base/exception_test.js
+++ b/tests/base/exception_test.js
@@ -49,5 +49,5 @@ function testException() {
   assertEquals(BASE_URL + '999&p0=' + expected, e4.message);
 
   var e5 = new lf.Exception(999, 3, undefined);
-  assertEquals(BASE_URL + '999&p0=3&p1=', e5.message);
+  assertEquals(BASE_URL + '999&p0=3&p1=undefined', e5.message);
 }

--- a/tests/base/exception_test.js
+++ b/tests/base/exception_test.js
@@ -47,4 +47,7 @@ function testException() {
 
   var e4 = new lf.Exception(999, longString);
   assertEquals(BASE_URL + '999&p0=' + expected, e4.message);
+
+  var e5 = new lf.Exception(999, 3, undefined);
+  assertEquals(BASE_URL + '999&p0=3&p1=', e5.message);
 }


### PR DESCRIPTION
We're seeing error reports from users that the error reporting in lovefield is failing — it's attempting to call `toString` on `undefined`.

This patch will allow us to see what the underlying error is.