### PR TITLE
added pull dependencies in bower.json to steps

### DIFF
--- a/demos/moviedb/README.md
+++ b/demos/moviedb/README.md
@@ -9,8 +9,9 @@ http://oak.cs.ucla.edu/cs143/project/data/data.zip.
 
 * Step 1: Install gulp (if you have not already), ```npm install -g gulp```
 * Step 2: Pull dependencies in package.json, ```npm install .```
-* Step 3: Start a local webserver, ```gulp debug```
-* Step 4: Navigate to [http://localhost:8000](http://localhost:8000),
+* Step 3: Pull dependencies in bower.json, ```bower install```
+* Step 4: Start a local webserver, ```gulp debug```
+* Step 5: Navigate to [http://localhost:8000](http://localhost:8000),
 
 ## demo-jquery
 


### PR DESCRIPTION
Omitting ```bower install``` will cause the following
...
[21:25:20] Starting 'copy_dependencies'...
[21:25:20] 'copy_dependencies' errored after 574 μs
[21:25:20] Error: ENOENT: no such file or directory, stat 'bower_components/bootstrap/dist/js/bootstrap.min.js'
...