### PR TITLE
Fix lovefield-spac in node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "spac/lovefield-spac",
     "spac/parser.js",
     "spac/spac.js",
-    "spac/template"
+    "spac/template",
+    "tools/node_bootstrap.js"
   ],
   "bin": {
     "lovefield-spac": "spac/lovefield-spac"


### PR DESCRIPTION
Fix this error. lovefield-spac need `tools/node_bootstrap.js` in node_modules.

```
$ node_modules/.bin/lovefield-spac --schema schema.yml --namespace mz --outputdir .
node_modules/.bin/lovefield-spac --schema schema.yml --namespace mz --outputdir .
module.js:471
    throw err;
    ^

Error: Cannot find module '/Users/mz/sandbox/lovefield-sandbox/node_modules/lovefield/tools/node_bootstrap.js'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at loadLovefield (/Users/mz/sandbox/lovefield-sandbox/node_modules/lovefield/spac/parser.js:34:27)
    at Object.<anonymous> (/Users/mz/sandbox/lovefield-sandbox/node_modules/lovefield/spac/parser.js:42:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
```

## How to check

`npm install @mizchi/lovefield` and run `node_modules/.bin/lovefield-spac`