### PR TITLE
Typescript fixes

### DIFF
--- a/dist/lovefield.d.ts
+++ b/dist/lovefield.d.ts
@@ -253,6 +253,6 @@ declare module lf {
 
 }  // module lf
 
-declare module 'lf' {
+declare module 'lovefield' {
   export = lf;
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lovefield",
   "version": "2.1.12",
   "main": "dist/lovefield.min.js",
+  "types": "dist/lovefield.d.ts",
   "description": "Lovefield - A relational database for web apps",
   "keywords": [
     "lovefield"


### PR DESCRIPTION
These two commits make `import 'lovefield'` work for me with TypeScript without needing to install `@types/lovefield`.