### PR TITLE
Update js-yaml to fix https://nodesecurity.io/advisories/788

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lovefield-spac": "spac/lovefield-spac"
   },
   "dependencies": {
-    "js-yaml": ">=3.1.0",
+    "js-yaml": "^3.13.0",
     "nopt": ">=2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I notice js-yaml is not updated to address https://nodesecurity.io/advisories/788.
So this is the patch.