### PR TITLE
Fix use of persistent index

### DIFF
--- a/lib/cache/prefetcher.js
+++ b/lib/cache/prefetcher.js
@@ -127,7 +127,7 @@ lf.cache.Prefetcher.prototype.fetchTableWithPersistentIndices_ = function(
 
   var store = tx.getTable(
       tableSchema.getName(),
-      tableSchema.deserializeRow,
+      tableSchema.deserializeRow.bind(tableSchema),
       lf.backstore.TableType.DATA);
   var whenTableContentsFetched = store.get([]).then(function(results) {
     this.cache_.setMany(tableSchema.getName(), results);


### PR DESCRIPTION
fix context binding when using TableSchema.deserializeRow function

should resolve [this issue](https://github.com/google/lovefield/issues/260)