### PR TITLE
Fix broken build

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "firebase-token-generator": "*",
     "fs-extra": ">=0.18.2",
     "glob": ">=3.2.6",
-    "google-closure-compiler-java": "latest",
+    "google-closure-compiler-java": "20200504.0.0",
     "google-closure-library": "20190618.0.0",
     "gulp": "4.0.2",
     "gulp-closure-compiler": ">=0.3.1",


### PR DESCRIPTION
Hello,

Build is broken with the latest google-closure-compiler. Specify version rather than latest for google-closure-compiler is better to make build stable to LTS support. 

All steps describe in contributing guide is passed with version 20200504.0.0, then that superior versions doesn't work!

Best regards