### PR TITLE
Fixed broken link to Google JavaScript Style Guide

### DIFF
--- a/docs/spec/00_intro.md
+++ b/docs/spec/00_intro.md
@@ -53,7 +53,7 @@ optimization.
 ## API Style
 
 1. All Lovefield API and source code must follow [Google JavaScript Style Guide
-   ](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+   ](https://google.github.io/styleguide/jsguide.html)
    and pass Closure compiler compilation. This implies that all APIs and
    source code are annotated with [Closure-style annotations](
    https://developers.google.com/closure/compiler/docs/js-for-compiler).


### PR DESCRIPTION
1. Fixed broken link to Google JavaScript Style Guide (the previous URL returned 404).
2. The previous URL pointed at the XML version of the Guide. Not sure if it was on purpose; anyway, the link I put points at the HTML version.