### PR TITLE
Reset cache

### DIFF
--- a/dist/lovefield.d.ts
+++ b/dist/lovefield.d.ts
@@ -17,242 +17,253 @@
 // Type definitions for Lovefield
 // Project: http://google.github.io/lovefield/
 
-/// <reference path="../es6-promise/es6-promise.d.ts"/>
 
-declare module lf {
-  export enum Order { ASC, DESC }
 
-  export enum Type {
-    ARRAY_BUFFER,
-    BOOLEAN,
-    DATE_TIME,
-    INTEGER,
-    NUMBER,
-    OBJECT,
-    STRING
-  }
-
-  export enum ConstraintAction {
-    RESTRICT,
-    CASCADE
-  }
-
-  export enum ConstraintTiming {
-    IMMEDIATE,
-    DEFERRABLE
-  }
-
-  export interface Binder {
-    getIndex(): number
-  }
-
-  export interface Predicate {}
-  export interface Row {}
-  type ValueLiteral = string|number|boolean|Date;
-
-  export interface PredicateProvider {
-    eq(operand: ValueLiteral|schema.Column|Binder): Predicate
-    neq(operand: ValueLiteral|schema.Column|Binder): Predicate
-    lt(operand: ValueLiteral|schema.Column|Binder): Predicate
-    lte(operand: ValueLiteral|schema.Column|Binder): Predicate
-    gt(operand: ValueLiteral|schema.Column|Binder): Predicate
-    gte(operand: ValueLiteral|schema.Column|Binder): Predicate
-    match(operand: RegExp|Binder): Predicate
-    between(from: ValueLiteral|Binder, to: ValueLiteral|Binder): Predicate
-    in(values: Binder|Array<ValueLiteral>): Predicate
-    isNull(): Predicate
-    isNotNull(): Predicate
-  }
-
-  function bind(index: number): Binder;
-
-  export interface TransactionStats {
-    success(): boolean
-    insertedRowCount(): Number
-    updatedRowCount(): Number
-    deletedRowCount(): Number
-    changedTableCount(): Number
-  }
-
-  export interface Transaction {
-    attach(query: query.Builder): Promise<Array<Object>>
-    begin(scope: Array<schema.Table>): Promise<void>
-    commit(): Promise<void>
-    exec(queries: Array<query.Builder>): Promise<Array<Array<Object>>>
-    rollback(): Promise<void>
-    stats(): TransactionStats
-  }
-
-  export enum TransactionType { READ_ONLY, READ_WRITE }
-
-  export interface Database {
-    close(): void
-    createTransaction(type?: TransactionType): Transaction
-    delete(): query.Delete
-    export(): Promise<Object>
-    getSchema(): schema.Database
-    import(data: Object): Promise<void>
-    insertOrReplace(): query.Insert
-    insert(): query.Insert
-    observe(query: query.Select, callback: Function): void
-    select(...columns: schema.Column[]): query.Select
-    unobserve(query: query.Select, callback: Function): void
-    update(table: schema.Table): query.Update
-  }
-
-  module query {
-    export interface Builder {
-      bind(...values: any[]): Builder
-      exec(): Promise<Array<Object>>
-      explain(): string
-      toSql(): string
+declare module 'lovefield' {
+  namespace lf {
+    export type Export = {
+      name: string;
+      version: number;
+      tables: Record<string, ReadonlyArray<Object>>;
+    };
+  
+    export enum Order { ASC, DESC }
+  
+    export enum Type {
+      ARRAY_BUFFER,
+      BOOLEAN,
+      DATE_TIME,
+      INTEGER,
+      NUMBER,
+      OBJECT,
+      STRING
     }
-
-    export interface Delete extends Builder {
-      from(table: schema.Table): Delete
-      where(predicate: Predicate): Delete
+  
+    export enum ConstraintAction {
+      RESTRICT,
+      CASCADE
     }
-
-    export interface Insert extends Builder {
-      into(table: schema.Table): Insert
-      values(rows: Array<Row>|Binder|Array<Binder>): Insert
+  
+    export enum ConstraintTiming {
+      IMMEDIATE,
+      DEFERRABLE
     }
-
-    export interface Select extends Builder {
-      from(...tables: schema.Table[]): Select
-      groupBy(...columns: schema.Column[]): Select
-      innerJoin(table: schema.Table, predicate: Predicate): Select
-      leftOuterJoin(table: schema.Table, predicate: Predicate): Select
-      limit(numberOfRows: Binder|number): Select
-      orderBy(column: schema.Column, order?: Order): Select
-      skip(numberOfRows: Binder|number): Select
-      where(predicate: Predicate): Select
+  
+    export interface Binder {
+      getIndex(): number
     }
-
-    export interface Update extends Builder {
-      set(column: schema.Column, value: any): Update
-      where(predicate: Predicate): Update
+  
+    export interface Predicate {}
+    export interface Row {}
+    type ValueLiteral = string|number|boolean|Date;
+  
+    export interface PredicateProvider {
+      eq(operand: ValueLiteral|schema.Column|Binder): Predicate
+      neq(operand: ValueLiteral|schema.Column|Binder): Predicate
+      lt(operand: ValueLiteral|schema.Column|Binder): Predicate
+      lte(operand: ValueLiteral|schema.Column|Binder): Predicate
+      gt(operand: ValueLiteral|schema.Column|Binder): Predicate
+      gte(operand: ValueLiteral|schema.Column|Binder): Predicate
+      match(operand: RegExp|Binder): Predicate
+      between(from: ValueLiteral|Binder, to: ValueLiteral|Binder): Predicate
+      in(values: Binder|ReadonlyArray<ValueLiteral>): Predicate
+      isNull(): Predicate
+      isNotNull(): Predicate
     }
-
-  }  // module query
-
-
-  module raw {
-    export interface BackStore {
-      getRawDBInstance(): any
-      getRawTransaction(): any
-      dropTable(tableName: string): Promise<void>
-      addTableColumn(
-          tableName: string, columnName: string,
-          defaultValue: string|boolean|number|Date|ArrayBuffer): Promise<void>
-      dropTableColumn(tableName: string, columnName:string): Promise<void>
-      renameTableColumn(
-          tableName: string, oldColumnName: string,
-          newColumnName:string) : Promise<void>
-      createRow(payload: Object): Row
-      getVersion(): number
-      dump(): Array<Object>
+  
+    function bind(index: number): Binder;
+  
+    export interface TransactionStats {
+      success(): boolean
+      insertedRowCount(): Number
+      updatedRowCount(): Number
+      deletedRowCount(): Number
+      changedTableCount(): Number
     }
-  }  // module raw
-
-
-  module schema {
-    export enum DataStoreType {
-      INDEXED_DB,
-      MEMORY,
-      LOCAL_STORAGE,
-      FIREBASE,
-      WEB_SQL
+  
+    export interface Transaction {
+      attach<T>(query: query.Builder): Promise<ReadonlyArray<Readonly<T>>>
+      begin(scope: ReadonlyArray<schema.Table>): Promise<void>
+      commit(): Promise<void>
+      exec(
+        queries: ReadonlyArray<query.Builder>
+      ): Promise<ReadonlyArray<ReadonlyArray<Readonly<object>>>>
+      rollback(): Promise<void>
+      stats(): TransactionStats
     }
-
-    export interface DatabasePragma {
-      enableBundledMode: boolean
-    }
-
+  
+    export enum TransactionType { READ_ONLY, READ_WRITE }
+  
     export interface Database {
-      name(): string
-      pragma(): DatabasePragma
-      tables(): Array<schema.Table>
-      table(tableName: string): schema.Table
-      version(): number
+      close(): void
+      createTransaction(type?: TransactionType): Transaction
+      delete(): query.Delete
+      export(): Promise<Export>
+      getSchema(): schema.Database
+      resetCache(): Promise<void>
+      import(data: Export): Promise<void>
+      insertOrReplace(): query.Insert
+      insert(): query.Insert
+      observe(query: query.Select, callback: Function): void
+      select(...columns: schema.Column[]): query.Select
+      unobserve(query: query.Select, callback: Function): void
+      update(table: schema.Table): query.Update
     }
-
-    export interface Column extends PredicateProvider {
-      as(name: string): Column
-      getName(): string
-      getNormalizedName(): string
-    }
-
-    export interface Table {
-      as(name: string): Table
-      createRow(value: Object): Row
-      getName(): string
-    }
-
-    export interface ConnectOptions {
-      onUpgrade?: (rawDb: raw.BackStore) => Promise<void>
-      storeType?: DataStoreType
-      webSqlDbSize?: number
-      // TODO(dpapad): firebase?
-    }
-
-    export interface Builder {
-      connect(options?: ConnectOptions): Promise<lf.Database>
-      createTable(tableName: string): TableBuilder
-      getSchema(): Database
-      setPragma(pragma: DatabasePragma): void
-    }
-
-    export interface IndexedColumn {
-      autoIncrement: boolean
-      name: string
-      order: Order
-    }
-
-    type RawForeignKeySpec = {
-      local: string
-      ref: string
-      action?: lf.ConstraintAction
-      timing?: lf.ConstraintTiming
-    }
-
-    export interface TableBuilder {
-      addColumn(name: string, type: lf.Type): TableBuilder
-      addForeignKey(name: string, spec: RawForeignKeySpec): TableBuilder
-      addIndex(
-          name: string, columns: Array<string>|Array<IndexedColumn>,
-          unique?: boolean, order?: Order): TableBuilder
-      addNullable(columns: Array<string>): TableBuilder
-      addPrimaryKey(
-          columns: Array<string>|Array<IndexedColumn>,
-          autoInc?: boolean): TableBuilder
-      addUnique(name: string, columns: Array<string>): TableBuilder
-    }
-
-    function create(dbName: string, dbVersion: number): Builder
-  }  // module schema
-
-
-  module op {
-    function and(...args: Predicate[]): Predicate;
-    function not(operand: Predicate): Predicate;
-    function or(...args: Predicate[]): Predicate;
-  }  // module op
-
-
-  module fn {
-    function avg(column: schema.Column): schema.Column
-    function count(column?: schema.Column): schema.Column
-    function distinct(column: schema.Column): schema.Column
-    function geomean(column: schema.Column): schema.Column
-    function max(column: schema.Column): schema.Column
-    function min(column: schema.Column): schema.Column
-    function stddev(column: schema.Column): schema.Column
-    function sum(column: schema.Column): schema.Column
-  }  // module fn
-
-}  // module lf
-
-declare module 'lf' {
+  
+    module query {
+      export interface Builder {
+        bind(...values: any[]): Builder
+        exec(): Promise<ReadonlyArray<Readonly<object>>>
+        explain(): string
+        toSql(): string
+      }
+  
+      export interface Delete extends Builder {
+        from(table: schema.Table): Delete
+        where(predicate: Predicate): Delete
+      }
+  
+      export interface Insert extends Builder {
+        into(table: schema.Table): Insert
+        values(rows: ReadonlyArray<Row>|Binder|ReadonlyArray<Binder>): Insert
+      }
+  
+      export interface Select extends Builder {
+        from(...tables: schema.Table[]): Select
+        groupBy(...columns: schema.Column[]): Select
+        innerJoin(table: schema.Table, predicate: Predicate): Select
+        leftOuterJoin(table: schema.Table, predicate: Predicate): Select
+        limit(numberOfRows: Binder|number): Select
+        orderBy(column: schema.Column, order?: Order): Select
+        skip(numberOfRows: Binder|number): Select
+        where(predicate: Predicate): Select
+      }
+  
+      export interface Update extends Builder {
+        set(column: schema.Column, value: any): Update
+        where(predicate: Predicate): Update
+      }
+  
+    }  // module query
+  
+  
+    module raw {
+      export interface BackStore {
+        getRawDBInstance(): any
+        getRawTransaction(): any
+        dropTable(tableName: string): Promise<void>
+        addTableColumn(
+            tableName: string, columnName: string,
+            defaultValue: string|boolean|number|Date|ArrayBuffer|null): Promise<void>
+        dropTableColumn(tableName: string, columnName:string): Promise<void>
+        renameTableColumn(
+            tableName: string, oldColumnName: string,
+            newColumnName:string) : Promise<void>
+        createRow(payload: Object): Row
+        getVersion(): number
+        dump(): Array<Object>
+      }
+    }  // module raw
+  
+  
+    module schema {
+      export enum DataStoreType {
+        INDEXED_DB,
+        MEMORY,
+        LOCAL_STORAGE,
+        FIREBASE,
+        WEB_SQL
+      }
+  
+      export interface DatabasePragma {
+        enableBundledMode: boolean
+      }
+  
+      export interface Database {
+        name(): string
+        pragma(): DatabasePragma
+        tables(): ReadonlyArray<schema.Table>
+        table(tableName: string): schema.Table
+        version(): number
+      }
+  
+      export interface Column extends PredicateProvider {
+        as(name: string): Column
+        getName(): string
+        getNormalizedName(): string
+      }
+  
+      export interface ITable {
+        as(name: string): Table
+        createRow(value: Object): Row
+        getName(): string
+      }
+  
+      export type Table = ITable & { [index: string]: Column }; 
+  
+      export interface ConnectOptions {
+        onUpgrade?: (rawDb: raw.BackStore) => Promise<void>
+        storeType?: DataStoreType
+        webSqlDbSize?: number
+        // TODO(dpapad): firebase?
+      }
+  
+      export interface Builder {
+        connect(options?: ConnectOptions): Promise<lf.Database>
+        createTable(tableName: string): TableBuilder
+        getSchema(): Database
+        setPragma(pragma: DatabasePragma): void
+      }
+  
+      export interface IndexedColumn {
+        autoIncrement: boolean
+        name: string
+        order: Order
+      }
+  
+      type RawForeignKeySpec = {
+        local: string
+        ref: string
+        action?: lf.ConstraintAction
+        timing?: lf.ConstraintTiming
+      }
+  
+      export interface TableBuilder {
+        addColumn(name: string, type: lf.Type): TableBuilder
+        addForeignKey(name: string, spec: RawForeignKeySpec): TableBuilder
+        addIndex(
+            name: string, columns: ReadonlyArray<string> | ReadonlyArray<IndexedColumn>,
+            unique?: boolean, order?: Order): TableBuilder
+        addNullable(columns: ReadonlyArray<string>): TableBuilder
+        addPrimaryKey(
+            columns: ReadonlyArray<string>|ReadonlyArray<IndexedColumn>,
+            autoInc?: boolean): TableBuilder
+        addUnique(name: string, columns: ReadonlyArray<string>): TableBuilder
+      }
+  
+      function create(dbName: string, dbVersion: number): Builder
+    }  // module schema
+  
+  
+    module op {
+      function and(...args: Predicate[]): Predicate;
+      function not(operand: Predicate): Predicate;
+      function or(...args: Predicate[]): Predicate;
+    }  // module op
+  
+  
+    module fn {
+      function avg(column: schema.Column): schema.Column
+      function count(column?: schema.Column): schema.Column
+      function distinct(column: schema.Column): schema.Column
+      function geomean(column: schema.Column): schema.Column
+      function max(column: schema.Column): schema.Column
+      function min(column: schema.Column): schema.Column
+      function stddev(column: schema.Column): schema.Column
+      function sum(column: schema.Column): schema.Column
+    }  // module fn
+  
+  }  // module lf
+  
   export = lf;
 }

--- a/lib/base.js
+++ b/lib/base.js
@@ -146,8 +146,13 @@ lf.base.closeDatabase = function(global) {
 lf.base.resetCache = function(global) {
   var schema = global.getService(lf.service.SCHEMA);
   var cache = global.getService(lf.service.CACHE);
-  cache.clear();
-  
-  var prefetcher = new lf.cache.Prefetcher(global);
-  return prefetcher.init(schema);
+  var indexStore = global.getService(lf.service.INDEX_STORE);
+
+  indexStore.clear();
+  return indexStore.init(schema).then(function() {
+    cache.dropRowCache();
+
+    var prefetcher = new lf.cache.Prefetcher(global);
+    return prefetcher.init(schema);
+  })
 };

--- a/lib/base.js
+++ b/lib/base.js
@@ -138,3 +138,16 @@ lf.base.closeDatabase = function(global) {
     // Swallow the exception if DB is not initialized yet.
   }
 };
+
+/**
+ * Resets the cache for the database
+ * @param {!lf.Global} global
+*/
+lf.base.resetCache = function(global) {
+  var schema = global.getService(lf.service.SCHEMA);
+  var cache = global.getService(lf.service.CACHE);
+  cache.clear();
+  
+  var prefetcher = new lf.cache.Prefetcher(global);
+  return prefetcher.init(schema);
+};

--- a/lib/cache/default_cache.js
+++ b/lib/cache/default_cache.js
@@ -136,3 +136,8 @@ lf.cache.DefaultCache.prototype.clear = function() {
   this.map_.clear();
   this.tableRows_.clear();
 };
+
+/** Drop row cache only so that it can be re-initialized with Prefetcher */
+lf.cache.DefaultCache.prototype.dropRowCache = function() {
+  this.map_.clear();
+};

--- a/lib/index/index_store.js
+++ b/lib/index/index_store.js
@@ -57,3 +57,8 @@ lf.index.IndexStore.prototype.getTableIndices;
  * @param {!lf.index.Index} index
  */
 lf.index.IndexStore.prototype.set;
+
+/**
+ * Resets the index store
+ */
+ lf.index.IndexStore.prototype.clear;

--- a/lib/index/memory_index_store.js
+++ b/lib/index/memory_index_store.js
@@ -126,3 +126,7 @@ lf.index.MemoryIndexStore.prototype.set = function(tableName, index) {
 lf.index.MemoryIndexStore.prototype.getTableIndices = function(tableName) {
   return this.tableIndices_.get(tableName) || [];
 };
+
+lf.index.MemoryIndexStore.prototype.clear = function() {
+  return this.tableIndices_.clear()
+};

--- a/lib/proc/database.js
+++ b/lib/proc/database.js
@@ -79,6 +79,11 @@ lf.proc.Database.prototype.getSchema = function() {
   return this.schema_;
 };
 
+/** @export */
+lf.proc.Database.prototype.resetCache = function() {
+  return lf.base.resetCache(this.global_);
+};
+
 
 /** @private */
 lf.proc.Database.prototype.checkActive_ = function() {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nopt": "2.2.1"
   },
   "scripts": {
-    "build": "gulp build --target=lib --mode=debug"
+    "build": "gulp build --target=lib --mode=opt && mv ./dist/lf.js ./dist/lovefield.min.js"
   },
   "devDependencies": {
     "chalk": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lovefield",
   "version": "2.1.12",
+  "types": "dist/lovefield.d.ts",
   "main": "dist/lovefield.min.js",
   "description": "Lovefield - A relational database for web apps",
   "keywords": [
@@ -28,26 +29,29 @@
     "lovefield-spac": "spac/lovefield-spac"
   },
   "dependencies": {
-    "js-yaml": ">=3.13.1",
-    "nopt": ">=2.2.1"
+    "js-yaml": "3.13.1",
+    "nopt": "2.2.1"
+  },
+  "scripts": {
+    "build": "gulp build --target=lib --mode=debug"
   },
   "devDependencies": {
-    "chalk": ">=0.5.1",
+    "chalk": "0.5.1",
     "firebase-token-generator": "*",
-    "fs-extra": ">=0.18.2",
-    "glob": ">=3.2.6",
+    "fs-extra": "0.30.0",
+    "glob": "3.2.6",
     "google-closure-compiler-java": "20200504.0.0",
     "google-closure-library": "20190618.0.0",
     "gulp": "4.0.2",
-    "gulp-closure-compiler": ">=0.3.1",
-    "gulp-connect": "^5.7.0",
-    "gulp-gjslint": ">=0.1.4",
+    "gulp-closure-compiler": "0.3.1",
+    "gulp-connect": "5.7.0",
+    "gulp-gjslint": "0.1.4",
     "jasmine": "^2.3.2",
-    "mkdirp": ">=0.5.0",
+    "mkdirp": "0.5.0",
     "request": "^2.88.0",
-    "selenium-webdriver": "^3.6.0",
-    "temporary": ">=0.0.8",
-    "toposort-class": ">=0.3.1"
+    "selenium-webdriver": "3.6.0",
+    "temporary": "0.0.8",
+    "toposort-class": "0.3.1"
   },
   "engines": {
     "node": ">=12.16.3"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lovefield-spac": "spac/lovefield-spac"
   },
   "dependencies": {
-    "js-yaml": ">=3.1.0",
+    "js-yaml": ">=3.13.1",
     "nopt": ">=2.2.1"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "firebase-token-generator": "*",
     "fs-extra": ">=0.18.2",
     "glob": ">=3.2.6",
-    "google-closure-compiler-java": "latest",
+    "google-closure-compiler-java": "20200504.0.0",
     "google-closure-library": "20190618.0.0",
     "gulp": "4.0.2",
     "gulp-closure-compiler": ">=0.3.1",


### PR DESCRIPTION
This PR adds the ability to reset the in-memory cache used by Lovefield (useful if another process changes the underlying IndexedDB data and you need to reset your cache to see it)

I don't expect this PR to get merged because the project is no longer accepting PRs. I'm just making this PR in case anybody else ever needs this and they want to copy this functionality into their own fork.